### PR TITLE
Integration with Azure Service Bus Namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## 0.2.0
+
+### Fix
+
+* Changes to ensure connection to Azure Service Bus. [Ben Dalling]
+
+
 ## 0.2.0 (2024-12-24)
 
 ### New

--- a/router.py
+++ b/router.py
@@ -33,6 +33,7 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
+import itertools
 import json
 import logging
 import os
@@ -311,6 +312,9 @@ class RouterRule:
         """
         if isinstance(message, str):
             return message
+        elif isinstance(message, memoryview):
+            message = message.tobytes()
+
         return message.decode('utf-8')
 
     def get_data(self, message: object) -> list:
@@ -344,7 +348,7 @@ class RouterRule:
         result = jmespath.search(self.jmespath, message)
 
         if isinstance(result, list):
-            return result
+            return list(itertools.chain.from_iterable(result))
         elif result is None:
             return []
 
@@ -740,7 +744,7 @@ class Router(MessagingHandler):
         for url in self.connections.keys():
             hostname = urlparse(url).hostname
             logger.debug(f'Creating a connection for {hostname}...')
-            connection = event.container.connect(url)
+            connection = event.container.connect(url, allowed_mechs='PLAIN')
             self.connections[url] = connection
             logger.info(f'Successfully created a connection for {hostname}.')
 

--- a/tests/features/connection-string-helper.feature
+++ b/tests/features/connection-string-helper.feature
@@ -9,9 +9,10 @@ Feature: Connection String Helper
     Then the AMQP URL is <amqp_url>
 
     Examples:
-      | sbus_connection_string                                                                                                           | amqp_url                                                       |
-      | Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;                             | amqps://RootManageSharedAccessKey:SAS_KEY_VALUE@localhost:5671 |
-      | Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true; | amqp://RootManageSharedAccessKey:SAS_KEY_VALUE@localhost:5672  |
+      | sbus_connection_string                                                                                                           | amqp_url                                                        |
+      | Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;                             | amqps://RootManageSharedAccessKey:SAS_KEY_VALUE@localhost:5671  |
+      | Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE=;                            | amqps://RootManageSharedAccessKey:SAS_KEY_VALUE=@localhost:5671 |
+      | Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true; | amqp://RootManageSharedAccessKey:SAS_KEY_VALUE@localhost:5672   |
 
   Scenario Outline: Invalid Connection Strings
     Given Azure Service Bus Connection String <sbus_connection_string>

--- a/tests/resources/docker-compose.yaml
+++ b/tests/resources/docker-compose.yaml
@@ -31,8 +31,8 @@ services:
       ROUTER_RULE_COUNTRY_GB: '{ "destination_namespaces": "GB", "destination_topics": "gb.topic", "jmespath": "country", "regexp": "^GB$", "source_subscription": "test", "source_topic": "topic.1"}'
       ROUTER_RULE_COUNTRY_FR: '{ "destination_namespaces": "", "destination_topics": "", "jmespath": "country", "regexp": "^$$ISO_3166_1_ALPHA_2$", "source_subscription": "test", "source_topic": "topic.1"}'
       ROUTER_RULE_COUNTRY_IE: '{ "destination_namespaces": "IE", "destination_topics": "ie.topic", "jmespath": "country", "regexp": "^IE$", "source_subscription": "test", "source_topic": "topic.2"}'
-      ROUTER_RULE_GB_TELNO: '{"destination_namespaces":"GB","destination_topics":"gb.topic","jmespath":"details[?telephone_number].telephone_number","regexp":"^\\+44","source_subscription":"test","source_topic":"topic.1"}'
-      ROUTER_RULE_IE_TELNO: '{"destination_namespaces":"IE","destination_topics":"ie.topic","jmespath":"details[?telephone_number].telephone_number","regexp":"^\\+353","source_subscription":"test","source_topic":"topic.2"}'
+      ROUTER_RULE_GB_TELNO: '{"destination_namespaces":"GB","destination_topics":"gb.topic","jmespath":"details[?telephone_number].telephone_number","regexp":"^.*44","source_subscription":"test","source_topic":"topic.1"}'
+      ROUTER_RULE_IE_TELNO: '{"destination_namespaces":"IE","destination_topics":"ie.topic","jmespath":"details[?telephone_number].telephone_number","regexp":"^.*353","source_subscription":"test","source_topic":"topic.2"}'
       ROUTER_SOURCE_CONNECTION_STRING: "Endpoint=sb://emulator;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
     image: router:latest
     ports:


### PR DESCRIPTION
This PR fixes some issues with connecting to an Azure Service Bus namespace and consuming and publishing data.  Specifically:
- Data from ASB is returned as a memoryview object.
- We need to connect over SSL with PLAIN mechanism.

Also fixes a problem with deeply nested results being returned by JMESPath. 