### PR TITLE
Hotfix/0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## Unreleased
 
+### Fix
+
+* More logging refactoring. [Ben Dalling]
+
+
+## 0.2.4 (2025-01-27)
+
 ### Features
 
 * Add the "ROUTER_ALLOWED_SASL_MECHS" environment variable. [Ben Dalling]

--- a/router.py
+++ b/router.py
@@ -78,7 +78,7 @@ def get_logger(logger_name: str, log_level=os.getenv('LOG_LEVEL', 'WARN')) -> lo
 
 logging.basicConfig()
 logger = get_logger(__file__)
-__version__ = '0.2.4'
+__version__ = '0.2.5'
 
 
 class ConnectionStringHelper:

--- a/router.py
+++ b/router.py
@@ -725,6 +725,10 @@ class Router(MessagingHandler):
         self.dlq_topic = config.get_dead_letter_queue()
         self.namespaces = config.service_bus_namespaces()
         self.rules = config.get_rules()
+
+        for idx, rule in enumerate(self.rules):
+            logger.info(f'Rule parsing order {idx} {rule.name()}')
+
         self.senders = {}
         self.sources = []
         self.source_namespace_connection_string = config.get_source_connection_string()
@@ -770,7 +774,7 @@ class Router(MessagingHandler):
         properties['source_topic'] = source_topic_name
         message.properties = properties
         message.send(self.senders['DLQ'])
-        logger.warning("Message from {source_topic_name} sent to the DLQ '{message.body}'.")
+        logger.warning(f'Message from {source_topic_name} sent to the DLQ "{message.body}".')
         DLQ_COUNT.inc()
 
     def on_connection_closed(self, event):

--- a/tests/resources/docker-compose.yaml
+++ b/tests/resources/docker-compose.yaml
@@ -28,8 +28,8 @@ services:
       ROUTER_DLQ_TOPIC: dlq
       ROUTER_NAMESPACE_GB_CONNECTION_STRING: "Endpoint=sb://emulator;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
       ROUTER_NAMESPACE_IE_CONNECTION_STRING: "Endpoint=sb://emulator;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
-      ROUTER_RULE_COUNTRY_GB: '{ "destination_namespaces": "GB", "destination_topics": "gb.topic", "jmespath": "country", "regexp": "^GB$", "source_subscription": "test", "source_topic": "topic.1"}'
       ROUTER_RULE_COUNTRY_FR: '{ "destination_namespaces": "", "destination_topics": "", "jmespath": "country", "regexp": "^$$ISO_3166_1_ALPHA_2$", "source_subscription": "test", "source_topic": "topic.1"}'
+      ROUTER_RULE_COUNTRY_GB: '{ "destination_namespaces": "GB", "destination_topics": "gb.topic", "jmespath": "country", "regexp": "^GB$", "source_subscription": "test", "source_topic": "topic.1"}'
       ROUTER_RULE_COUNTRY_IE: '{ "destination_namespaces": "IE", "destination_topics": "ie.topic", "jmespath": "country", "regexp": "^IE$", "source_subscription": "test", "source_topic": "topic.2"}'
       ROUTER_RULE_GB_TELNO: '{"destination_namespaces":"GB","destination_topics":"gb.topic","jmespath":"details[?telephone_number].telephone_number","regexp":"^.*44","source_subscription":"test","source_topic":"topic.1"}'
       ROUTER_RULE_IE_TELNO: '{"destination_namespaces":"IE","destination_topics":"ie.topic","jmespath":"details[?telephone_number].telephone_number","regexp":"^.*353","source_subscription":"test","source_topic":"topic.2"}'


### PR DESCRIPTION
Fix a couple of problems in logging:
- Show the ordering that rules will be applied in start-up.
- Fix a typo so we can identify messages (and therefore why) that are placed on the DLQ.