### PR TITLE
Performance Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## Unreleased
+
+### Fix
+
+* Bump the prefetch count from 20 to 100 and allow it to be configured. [Ben Dalling]
+
+* Pre-compile JMESPath expressions. [Ben Dalling]
+
+
 ## 0.5.2 (2025-05-16)
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ least one rule configured  (see below).
 | LOG_LEVEL | | WARN | The log level for the router.|
 | ROUTER_CUSTOM_SENDER | No | N/A | See below. |
 | ROUTER_MAX_TASKS | No | 1 | The number of tasks to allocate to each topic/subscription. |
+| ROUTER_PREFETCH_COUNT | No | 100 | The maximum number of messages to cache with each request to the service. |
 | ROUTER_PROMETHEUS_PORT | No | 8000 | The port for Prometheus to start on. |
 | ROUTER_SOURCE_CONNECTION_STRING | Yes | | The connection string for the source Service Bus namespace. |
 

--- a/router.py
+++ b/router.py
@@ -177,6 +177,12 @@ class RouterRule:
 
         self.is_session_required = parsed_definition.get('is_session_required', False)
         self.jmespath = parsed_definition.get('jmespath', None)
+
+        if self.jmespath:
+            self.jmespath_expr = jmespath.compile(self.jmespath)
+        else:
+            self.jmespath_expr = None
+
         self.regexp = parsed_definition.get('regexp', None)
 
         if self.regexp:
@@ -234,7 +240,7 @@ class RouterRule:
         except json.decoder.JSONDecodeError:
             return []
 
-        result = jmespath.search(self.jmespath, message_json)
+        result = self.jmespath_expr.search(message_json)
 
         if isinstance(result, list):
             return self.flatten_list(result)


### PR DESCRIPTION
This PR:
- Pre-compiles the JMESPath expressions provided in the rule definitions.
- Bumps the pre-fetch count for the receivers from 20 to 100 while also allowing the number to be configured by an environment variable.