### PR TITLE
Trivy scan vulnerabilities found in image 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## Unreleased
+
+### Build
+
+* Upgrade libdjvulibre to fix CVE-2025-53367. [Ben Dalling]
+
+
 ## 0.7.0 (2025-06-25)
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ LABEL org.opencontainers.image.description "A configurable router for Azure Serv
 # hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get install --no-install-recommends --yes bind9-dnsutils ncat \
+  && apt-get upgrade --yes libdjvulibre-dev libdjvulibre-text libdjvulibre21 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && addgroup --gid 1000 appuser \

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -4,8 +4,6 @@ exit-code: 1
 
 format: table
 
-ignore-unfixed: true
-
 pkg:
   type:
     - os


### PR DESCRIPTION
This PR resolves CVE-2025-53367 (fixes #99).