### PR TITLE
Check for Dead Letter Messages on Source Topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## Unreleased
 
+### Features
+
+* Add checks for DLQ on source topics. [Ben Dalling]
+
+* Allow the user to configure the log format via an environment variable. [Ben Dalling]
+
 ### Build
 
 * Upgrade libdjvulibre to fix CVE-2025-53367. [Ben Dalling]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ least one rule configured  (see below).
 
 | Environment Variable | Required | Default | Description |
 | -------------------- | -------- | ------- | ----------- |
+| LOG_FORMAT | No | "%(levelname)s [%(filename)s:%(lineno)d] %(message)s" | The log format (passed to `logging.basicConfig) |
 | LOG_LEVEL | | WARN | The log level for the router.|
 | ROUTER_CUSTOM_SENDER | No | N/A | See below. |
 | ROUTER_MAX_TASKS | No | 1 | The number of tasks to allocate to each topic/subscription. |
@@ -75,3 +76,11 @@ I/O.  The function MUST be defined to accept the following arguments:
 
 An example custom sender is implemented in the file
 `tests/resources/custom.py`.
+
+## Useful External Links
+
+The followng links can assist in crafting rules and regular expressions:
+
+- https://gchq.github.io/CyberChef
+- https://pythex.org
+- https://play.jmespath.org

--- a/router.py
+++ b/router.py
@@ -82,7 +82,12 @@ def get_logger(logger_name: str, log_level=os.getenv('LOG_LEVEL', 'WARN')) -> lo
     return logger
 
 
-logging.basicConfig(format='%(levelname)s [%(filename)s:%(lineno)d] %(message)s')
+logging.basicConfig(
+    format=os.environ.get(
+        'LOG_FORMAT',
+        '%(levelname)s [%(filename)s:%(lineno)d] %(message)s'
+    )
+)
 logger = get_logger(__file__)
 custom_sender_string = os.getenv('ROUTER_CUSTOM_SENDER')
 

--- a/tests/features/data-flow.feature
+++ b/tests/features/data-flow.feature
@@ -16,6 +16,7 @@ Scenario Outline: Inject a Message and Confirm the Destination
         | input_data_file | input_topic   | output_topic |
         | input-6.json    | topic.2       | DLQ          |
         | input-1.json    | topic.1       | gb.topic     |
+        | input-6.json    | topic.1       | DLQ          |
         | input-2.json    | topic.2       | ie.topic     |
         | input-3.json    | topic.1       | gb.topic     |
         | input-4.json    | topic.2       | ie.topic     |
@@ -23,5 +24,5 @@ Scenario Outline: Inject a Message and Confirm the Destination
 
 Scenario: Replay DLQ Message
     Given the landing Service Bus Emulator
-    Then the DLQ count is 1
+    Then the DLQ count is 2
     Then the deleted DLQ messages is 1

--- a/tests/resources/docker-compose.yaml
+++ b/tests/resources/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
         condition: service_completed_successfully
     environment:
       ISO_3166_1_ALPHA_2: FR
+      LOG_FORMAT: "%(asctime)s %(levelname)s [%(filename)s:%(lineno)d] %(message)s"
       LOG_LEVEL: DEBUG
       ROUTER_CUSTOM_SENDER: "custom:custom_sender"
       ROUTER_MAX_TASKS: 2

--- a/tests/step_defs/test_data_flow.py
+++ b/tests/step_defs/test_data_flow.py
@@ -66,12 +66,12 @@ def _(connection_string: str, input_topic: str, output_topic: str, message_body:
         pytest.skip(f'Output topic is "{output_topic}".')
 
 
-@then('the DLQ count is 1')
+@then('the DLQ count is 2')
 def _():
     """the DLQ count is 1."""
     host = testinfra.get_host('docker://router')
     cmd = host.run('curl localhost:8000')
-    assert 'dlq_message_count_total 1.0' in cmd.stdout
+    assert 'dlq_message_count_total 2.0' in cmd.stdout
 
 
 @then('the deleted DLQ messages is 1')


### PR DESCRIPTION
This PR:
- Will give hourly warnings of any messages that are dead-lettered on the source topics (fixes #95).
- Given the extra activity on those topics, this will also ensure that they remain active, even if no messages are received (fixes #98 for source topics at least).
- Allows the user to craft the format of output logs (add the timestamp for example).
- Adds some useful links to the `README.md` to assist in crafting rules (fixes #94).

Example log output (INFO level):

```
router  | 2025-07-15 14:46:04,378 INFO [router.py:96] Configuring custom sender "custom:custom_sender".
router  | 2025-07-15 14:46:04,379 INFO [router.py:879] Starting version "0.7.0".
router  | 2025-07-15 14:46:04,384 INFO [router.py:597] Starting 2 task(s) per subscription.
router  | 2025-07-15 14:46:04,384 INFO [router.py:600] Rule parsing order 0 COUNTRY_FR
router  | 2025-07-15 14:46:04,384 INFO [router.py:600] Rule parsing order 1 COUNTRY_GB
router  | 2025-07-15 14:46:04,384 INFO [router.py:600] Rule parsing order 2 COUNTRY_IE
router  | 2025-07-15 14:46:04,384 INFO [router.py:600] Rule parsing order 3 GB_TELNO
router  | 2025-07-15 14:46:04,384 INFO [router.py:600] Rule parsing order 4 IE_TELNO
router  | 2025-07-15 14:46:21,875 WARNING [router.py:767] No rules match message from topic.2, sending to the DLQ.
router  | 2025-07-15 14:46:25,643 WARNING [router.py:767] No rules match message from topic.1, sending to the DLQ.
router  | 2025-07-15 14:50:07,015 WARNING [router.py:723] DLQ has messages for topic.1/test
```