### PR TITLE
Release/0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 * Provide the destination when marking sending as failed. [Ben Dalling]
 
+### Build
+
+* Release/0.9.1 (to replace 0.10.0) [Ben Dalling]
+
 ### Performance
 
 * Only parse JSON messages once. [Ben Dalling]

--- a/router.py
+++ b/router.py
@@ -57,7 +57,7 @@ from azure.servicebus.amqp import AmqpMessageBodyType
 from azure.servicebus.exceptions import OperationTimeoutError
 from prometheus_client import Counter, Summary, start_http_server
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 PROCESSING_TIME = Summary('message_processing_seconds', 'The time spent processing messages.')
 DLQ_COUNT = Counter('dlq_message_count', 'The number of messages sent to the DLQ.')
 


### PR DESCRIPTION
We erroneously created a release 0.10.0 for these same changes but that was a mistake as no new functionality was delivered by the change.  We cleaned up 0.10.0 (within seconds of it being there so nobody would have consumed it), and this is the correctly labeled 0.9.1 release.

### Fix

* Cleaner shutdown. [Ben Dalling]

* Provide the destination when marking sending as failed. [Ben Dalling]

### Performance

* Only parse JSON messages once. [Ben Dalling]
