### PR TITLE
Release/2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## Unreleased
+
+### Build
+
+* Release/2.2.2. [Ben Dalling]
+
+
 ## 2.2.1 (2026-04-07)
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## Unreleased
+## 2.2.1 (2026-04-07)
 
 ### Fix
 

--- a/router.py
+++ b/router.py
@@ -61,7 +61,7 @@ from azure.servicebus.amqp import AmqpMessageBodyType
 from azure.servicebus.exceptions import OperationTimeoutError
 from prometheus_client import Counter, Summary, start_http_server
 
-__version__ = '2.2.1'
+__version__ = '2.2.2'
 PROCESSING_TIME = Summary('message_processing_seconds', 'The time spent processing messages.')
 DLQ_COUNT = Counter('dlq_message_count', 'The number of messages sent to the DLQ.')
 SESSION_RECEIVER_CREATED = Counter(


### PR DESCRIPTION
Maintenance release.  Clean Trivy scan during the build pipeline <https://github.com/cbdq-io/sbus-router/actions/runs/24825677124/job/72660885105>.