### PR TITLE
Release/2.2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: docker build -t router:${{ github.sha }} .
 
       - name: Trivy Scan
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: router:${{ github.sha }}
           scanners: vuln

--- a/.github/workflows/periodic-trivy-scan.yml
+++ b/.github/workflows/periodic-trivy-scan.yml
@@ -42,7 +42,7 @@ jobs:
           echo "tag=$semver_tag" >> $GITHUB_OUTPUT
 
       - name: Run Trivy scan and output SARIF
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         continue-on-error: true
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ steps.get-tag.outputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## Unreleased
+## 2.2.2 (2026-04-23)
 
 ### Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
 
+## Unreleased
+
+### Fix
+
+* CVE-2026-44432 no longer on the image. [Ben Dalling]
+
+### Build
+
+* Bump aquasecurity/trivy-action from 0.35.0 to 0.36.0. [dependabot[bot]]
+
+  Bumps [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action) from 0.35.0 to 0.36.0.
+  - [Commits](https://github.com/aquasecurity/trivy-action/compare/0.35.0...v0.36.0)
+
+  ---
+  updated-dependencies:
+  - dependency-name: aquasecurity/trivy-action
+    dependency-version: 0.36.0
+    dependency-type: direct:production
+    update-type: version-update:semver-minor
+  ...
+
+
 ## 2.2.2 (2026-04-23)
 
 ### Build

--- a/router.py
+++ b/router.py
@@ -61,7 +61,7 @@ from azure.servicebus.amqp import AmqpMessageBodyType
 from azure.servicebus.exceptions import OperationTimeoutError
 from prometheus_client import Counter, Summary, start_http_server
 
-__version__ = '2.2.2'
+__version__ = '2.2.3'
 PROCESSING_TIME = Summary('message_processing_seconds', 'The time spent processing messages.')
 DLQ_COUNT = Counter('dlq_message_count', 'The number of messages sent to the DLQ.')
 SESSION_RECEIVER_CREATED = Counter(


### PR DESCRIPTION
### Fix

* CVE-2026-44432 no longer on the image. [Ben Dalling]

### Build

* Bump aquasecurity/trivy-action from 0.35.0 to 0.36.0. [dependabot[bot]]

  Bumps [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action) from 0.35.0 to 0.36.0.
  - [Commits](https://github.com/aquasecurity/trivy-action/compare/0.35.0...v0.36.0)

  ---
  updated-dependencies:
  - dependency-name: aquasecurity/trivy-action
    dependency-version: 0.36.0
    dependency-type: direct:production
    update-type: version-update:semver-minor
  ...